### PR TITLE
reformat code based on air

### DIFF
--- a/R/COA_Tag_Integrated.R
+++ b/R/COA_Tag_Integrated.R
@@ -27,23 +27,22 @@
 #' @seealso [rstan::sampling()]
 #' @export
 COA_TagInt <- function(
-    nind,
-    nrec,
-    ntime,
-    ntest,
-    ntrans,
-    y,
-    test,
-    recX,
-    recY,
-    xlim,
-    ylim,
-    testX,
-    testY,
-    ndraws = NULL,
-    ...
+  nind,
+  nrec,
+  ntime,
+  ntest,
+  ntrans,
+  y,
+  test,
+  recX,
+  recY,
+  xlim,
+  ylim,
+  testX,
+  testY,
+  ndraws = NULL,
+  ...
 ) {
-
   # First move everything into a list
   standata <- list(
     nind = nind,
@@ -62,8 +61,7 @@ COA_TagInt <- function(
   )
 
   # validate this list prior to sending it to the model
-  exp_len <- expected_lengths(recX = recX, recY = recY,
-                              ntest_len = ntest)
+  exp_len <- expected_lengths(recX = recX, recY = recY, ntest_len = ntest)
 
   validate_standata(standata, exp_len)
   # set rstan options
@@ -88,9 +86,11 @@ COA_TagInt <- function(
   # How much time did fitting take (in minutes)?
   fit_time <- sum(print(rstan::get_elapsed_time(fit_model))) / 60
   # # calculate generated quantities
-  fit_generated_quantities <- generated_quantities(model = fit_model,
-                                                   standata = standata,
-                                                   ndraws = ndraws)
+  fit_generated_quantities <- generated_quantities(
+    model = fit_model,
+    standata = standata,
+    ndraws = ndraws
+  )
   # transform gq into matrix
   tran_fit_gq <- transform_gq(fit_generated_quantities)
 

--- a/R/COA_TimeVarying.R
+++ b/R/COA_TimeVarying.R
@@ -35,7 +35,6 @@ COA_TimeVarying <- function(
   ndraws = NULL,
   ...
 ) {
-
   # First move everything into a list
   standata <- list(
     nind = nind,
@@ -53,7 +52,7 @@ COA_TimeVarying <- function(
 
   validate_standata(standata, exp_len)
 
-    # set rstan options
+  # set rstan options
   rstan::rstan_options(auto_write = TRUE)
   # set coores - this probably should be an argument
   options(mc.cores = parallel::detectCores())
@@ -72,9 +71,11 @@ COA_TimeVarying <- function(
   fit_time <- sum(print(rstan::get_elapsed_time(fit_model))) / 60
 
   # calculate generated quantities
-  fit_generated_quantities <- generated_quantities(model = fit_model,
-                                                   standata = standata,
-                                                   ndraws = ndraws)
+  fit_generated_quantities <- generated_quantities(
+    model = fit_model,
+    standata = standata,
+    ndraws = ndraws
+  )
   # transform gq into matrix
   tran_fit_gq <- transform_gq(fit_generated_quantities)
   # Extract COA estimates

--- a/R/COA_standard.R
+++ b/R/COA_standard.R
@@ -24,19 +24,18 @@
 #'
 #' @export
 COA_Standard <- function(
-    nind,
-    nrec,
-    ntime,
-    ntrans,
-    y,
-    recX,
-    recY,
-    xlim,
-    ylim,
-    ndraws = NULL,
-    ...
+  nind,
+  nrec,
+  ntime,
+  ntrans,
+  y,
+  recX,
+  recY,
+  xlim,
+  ylim,
+  ndraws = NULL,
+  ...
 ) {
-
   # First move everything into a list
   standata <- list(
     nind = nind,
@@ -74,9 +73,11 @@ COA_Standard <- function(
   fit_time <- sum(print(rstan::get_elapsed_time(fit_model))) / 60
 
   # calculate generated quantities
-  fit_generated_quantities <- generated_quantities(model = fit_model,
-                                                   standata = standata,
-                                                   ndraws = ndraws)
+  fit_generated_quantities <- generated_quantities(
+    model = fit_model,
+    standata = standata,
+    ndraws = ndraws
+  )
   # transform gq into matrix
   tran_fit_gq <- transform_gq(fit_generated_quantities)
   # Extract COA estimates
@@ -113,19 +114,21 @@ COA_Standard <- function(
 
   coas <- as.data.frame(coas[,, 1])
   # Report results
-  model_results <- list(fit_model,
-                        fit_summary,
-                        fit_time,
-                        coas,
-                        fit_estimates,
-                        tran_fit_gq
-                        )
-  names(model_results) <- c('model',
-                            'summary',
-                            'time',
-                            'coas',
-                            'all_estimates',
-                            'generated_quantities'
-                            )
+  model_results <- list(
+    fit_model,
+    fit_summary,
+    fit_time,
+    coas,
+    fit_estimates,
+    tran_fit_gq
+  )
+  names(model_results) <- c(
+    'model',
+    'summary',
+    'time',
+    'coas',
+    'all_estimates',
+    'generated_quantities'
+  )
   return(model_results)
 }

--- a/R/distf.R
+++ b/R/distf.R
@@ -5,10 +5,9 @@
 #' @export
 #' @param x Data frame or matrix containing 2-dimensional coordinates
 #' @param y Data frame or matrix containing 2-dimensional coordinates
-#' @return 'distf' returns a matrix containing the Euclidean distance between each location in dataframe x with that in dataframe y 
+#' @return 'distf' returns a matrix containing the Euclidean distance between each location in dataframe x with that in dataframe y
 #'
-distf=function (x, y) 
-{
+distf = function(x, y) {
   i = sort(rep(1:nrow(y), nrow(x)))
   dvec = sqrt((x[, 1] - y[i, 1])^2 + (x[, 2] - y[i, 2])^2)
   matrix(dvec, nrow = nrow(x), ncol = nrow(y), byrow = F)

--- a/R/generated_quantities.R
+++ b/R/generated_quantities.R
@@ -10,10 +10,7 @@
 #' @keywords internal
 #' @name generated_quantities
 
-generated_quantities <- function(model,
-                                 standata,
-                                 ndraws = NULL) {
-
+generated_quantities <- function(model, standata, ndraws = NULL) {
   # check stan object
   check_stan_object(model)
   # check to see if ntest is in standata this will allow for gq's to be made
@@ -56,23 +53,26 @@ generated_quantities <- function(model,
     }
     # create blank array with the name of eveyrhting
 
-    yrep <- array(NA, c(nind, nrec, ntime),
-                  dimnames = list(
-                    tag = seq_len(nind),
-                    rec = seq_len(nrec),
-                    time = seq_len(ntime)
-                  )
+    yrep <- array(
+      NA,
+      c(nind, nrec, ntime),
+      dimnames = list(
+        tag = seq_len(nind),
+        rec = seq_len(nrec),
+        time = seq_len(ntime)
+      )
     )
 
     if (check_test_tag) {
-      yrep_test <- array(NA, c(ntest, nrec, ntime),
-                         dimnames = list(
-                           tag = seq_len(ntest),
-                           rec = seq_len(nrec),
-                           time = seq_len(ntime)
-                         )
+      yrep_test <- array(
+        NA,
+        c(ntest, nrec, ntime),
+        dimnames = list(
+          tag = seq_len(ntest),
+          rec = seq_len(nrec),
+          time = seq_len(ntime)
+        )
       )
-
     }
     # ----- generate quantities ------
     # First for number of detections for each tagged individual
@@ -80,15 +80,17 @@ generated_quantities <- function(model,
       for (i in 1:nind) {
         for (j in 1:nrec) {
           # create distances
-          d <- sqrt((sx[draw, i, t] - recX[j]) ^ 2 +
-                      (sy[draw, i, t] - recY[j]) ^ 2)
+          d <- sqrt(
+            (sx[draw, i, t] - recX[j])^2 +
+              (sy[draw, i, t] - recY[j])^2
+          )
           # make this work for when p0 is dimensions
           if (is.matrix(p0)) {
             base <- p0[t, j]
-          } else{
+          } else {
             base <- p0
           }
-          p <- base * exp(-a1 * d ^ 2)
+          p <- base * exp(-a1 * d^2)
           # make sure the pobablity is above 0
           p <- min(max(p, 1e-9), 1 - 1e-9)
           # then run int using a the iteration of transmission by probability
@@ -105,9 +107,9 @@ generated_quantities <- function(model,
         for (m in 1:nrec) {
           for (s in 1:ntest) {
             # Euclidean distance between test tag s and receiver m
-            td <- sqrt((testX[s] - recX[m]) ^ 2 + (testY[s] - recY[m]) ^ 2)
+            td <- sqrt((testX[s] - recX[m])^2 + (testY[s] - recY[m])^2)
             # Probability
-            ptest <- p0[l, m] * exp(-a1 * td ^ 2)
+            ptest <- p0[l, m] * exp(-a1 * td^2)
             ptest <- min(max(ptest, 1e-9), 1 - 1e-9)
             # Simulate detection
             yrep_test[s, m, l] <- stats::rbinom(1, ntrans, ptest)
@@ -118,8 +120,7 @@ generated_quantities <- function(model,
     }
   }
   if (check_test_tag) {
-    return(list(yrep = yrep_list,
-                testrep = yrep_test_list))
+    return(list(yrep = yrep_list, testrep = yrep_test_list))
   } else {
     return(list(yrep = yrep_list))
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,15 +8,15 @@
 #' @keywords internal
 #' @name error_functions
 
-
 check_num_vec_len <- function(x, vec_length = NULL, arg_name = NULL) {
-
   if (is.null(arg_name)) {
     arg_name <- rlang::as_label(rlang::enexpr(x))
   }
 
   if (!is.numeric(x) || !is.vector(x) || length(x) != vec_length) {
-    cli::cli_abort("`{arg_name}` must be a numeric vector that has a length of {vec_length}.")
+    cli::cli_abort(
+      "`{arg_name}` must be a numeric vector that has a length of {vec_length}."
+    )
   }
 }
 
@@ -27,7 +27,6 @@ check_num_vec_len <- function(x, vec_length = NULL, arg_name = NULL) {
 #' @name error_functions
 
 check_array <- function(x, arg_name = NULL) {
-
   if (is.null(arg_name)) {
     arg_name <- rlang::as_label(rlang::enexpr(x))
   }
@@ -35,7 +34,6 @@ check_array <- function(x, arg_name = NULL) {
   if (!is.array(x) || !is.numeric(x) || length(dim(x)) != 3) {
     cli::cli_abort("`{arg_name}` must be a 3-dimensional numeric array.")
   }
-
 }
 
 
@@ -48,11 +46,9 @@ check_array <- function(x, arg_name = NULL) {
 #' @name error_functions
 #'
 check_array_tag <- function(x, len, arg_name = NULL) {
-
   if (is.null(arg_name)) {
     arg_name <- rlang::as_label(rlang::enexpr(x))
   }
-
 
   if (!is.array(x) || !is.numeric(x) || length(x) != len) {
     cli::cli_abort(
@@ -73,12 +69,14 @@ check_stan_object <- function(x, arg_name = NULL) {
   }
 
   # valid classes from rstan and cmdstanr
-  valid_classes <- c("stanfit",
-                     "stanmodel",
-                     "CmdStanMCMC",
-                     "CmdStanMLE",
-                     "CmdStanVB",
-                     "CmdStanModel")
+  valid_classes <- c(
+    "stanfit",
+    "stanmodel",
+    "CmdStanMCMC",
+    "CmdStanMLE",
+    "CmdStanVB",
+    "CmdStanModel"
+  )
 
   if (!inherits(x, valid_classes)) {
     cli::cli_abort(
@@ -98,10 +96,7 @@ check_stan_object <- function(x, arg_name = NULL) {
 #' @keywords internal
 #' @name expected_lengths
 
-expected_lengths <- function(recX = NULL,
-                             recY = NULL,
-                             ntest_len = NULL) {
-
+expected_lengths <- function(recX = NULL, recY = NULL, ntest_len = NULL) {
   if (!is.null(ntest_len)) {
     check_num_vec_len(ntest_len, vec_length = 1, arg_name = "ntest")
   }
@@ -132,9 +127,7 @@ expected_lengths <- function(recX = NULL,
 #' @name vaidate_standata
 
 validate_standata <- function(standata, lengths) {
-
-  array_vars <- intersect(c("y", "test", "testX",
-                            "testY"), names(standata))
+  array_vars <- intersect(c("y", "test", "testX", "testY"), names(standata))
 
   for (var in array_vars) {
     # check station locations
@@ -147,16 +140,16 @@ validate_standata <- function(standata, lengths) {
   }
 
   # check vectors
-  mapply(FUN = function(len, name) {
-
-    if (!(name %in% array_vars) && !is.null(len) && !is.null(standata[[name]])) {
-
-      check_num_vec_len(standata[[name]],
-                        vec_length = len,
-                        arg_name = name)
-    }
-  },
-  lengths, names(lengths)
+  mapply(
+    FUN = function(len, name) {
+      if (
+        !(name %in% array_vars) && !is.null(len) && !is.null(standata[[name]])
+      ) {
+        check_num_vec_len(standata[[name]], vec_length = len, arg_name = name)
+      }
+    },
+    lengths,
+    names(lengths)
   )
 }
 
@@ -193,8 +186,8 @@ transform_gq <- function(input) {
     dim_x <- dim(open_input[[1]])
 
     grid <- expand.grid(
-      tag  = seq_len(dim_x[1]),
-      rec  = seq_len(dim_x[2]),
+      tag = seq_len(dim_x[1]),
+      rec = seq_len(dim_x[2]),
       time = seq_len(dim_x[3])
     )
 
@@ -203,9 +196,7 @@ transform_gq <- function(input) {
       paste0("tag_", idx[1], "_rec_", idx[2], "_time_", idx[3])
     })
     return(rep_mat)
-
   })
   names(output) <- post_type
   output
 }
-

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,8 @@
 .onLoad <- function(libname, pkgname) {
   modules <- paste0("stan_fit4", names(stanmodels), "_mod")
-  for (m in modules) loadModule(m, what = TRUE)
+  for (m in modules) {
+    loadModule(m, what = TRUE)
+  }
 }
 
 # ---- global variables ------

--- a/tests/testthat/setup-test-env.R
+++ b/tests/testthat/setup-test-env.R
@@ -24,14 +24,15 @@ standata_1 <- list(
   ntest = nsentinal,
   test = testY,
   testX = array(testloc$east, dim = c(nsentinal)),
-  testY = array(testloc$north, dim = c(nsentinal))# N-S b
+  testY = array(testloc$north, dim = c(nsentinal)) # N-S b
 )
 
 # ----- run each model ------
 # ----- standard coa ------
 model_coa_standard <- do.call(
   COA_Standard,
-  c(standata,
+  c(
+    standata,
     list(
       chains = 2,
       warmup = 1000,
@@ -45,7 +46,8 @@ model_coa_standard <- do.call(
 # ----- time integrated -----
 model_coa_time_vary <- do.call(
   COA_TimeVarying,
-  c(standata,
+  c(
+    standata,
     list(
       chains = 2,
       warmup = 3000,
@@ -60,7 +62,8 @@ model_coa_time_vary <- do.call(
 # ----- tag integraged -----
 model_coa_tag_int <- do.call(
   COA_TagInt,
-  c(standata_1,
+  c(
+    standata_1,
     list(
       chains = 2,
       warmup = 4000,
@@ -71,5 +74,3 @@ model_coa_tag_int <- do.call(
     )
   )
 )
-
-

--- a/tests/testthat/test-COA_Standard.R
+++ b/tests/testthat/test-COA_Standard.R
@@ -15,7 +15,7 @@ coa_args <- list(
   ylim = example_extent$ylim,
   chains = 2,
   warmup = 1000,
-  iter   = 2000,
+  iter = 2000,
   control = list(adapt_delta = 0.95)
 )
 
@@ -53,12 +53,12 @@ params_table <- list(
   ),
   list(
     param = "recX",
-    bad   = list("a", NA),
+    bad = list("a", NA),
     regex = "`recX` must be a numeric vector that has a length of 1."
   ),
   list(
     param = "recY",
-    bad   = list("a", NA),
+    bad = list("a", NA),
     regex = "`recY` must be a numeric vector that has a length of 1."
   ),
   list(
@@ -81,21 +81,27 @@ params_table <- list(
 # ----- Check Params -----
 
 test_that("parameter validation works", {
-
   for (pt in params_table) {
     for (bad_val in pt$bad) {
-      tryCatch({
-        expect_error(
-          call_coa(setNames(list(bad_val), pt$param)),
-          regexp = pt$regex,
-          label = sprintf("param=%s, bad_val=%s", pt$param, deparse(bad_val))
-        )
-      },
-      error = function(e) {
-        cat("\n Error for param:", pt$param,
-            " bad_val:", deparse(bad_val), "\n")
-        stop(e)
-      })
+      tryCatch(
+        {
+          expect_error(
+            call_coa(setNames(list(bad_val), pt$param)),
+            regexp = pt$regex,
+            label = sprintf("param=%s, bad_val=%s", pt$param, deparse(bad_val))
+          )
+        },
+        error = function(e) {
+          cat(
+            "\n Error for param:",
+            pt$param,
+            " bad_val:",
+            deparse(bad_val),
+            "\n"
+          )
+          stop(e)
+        }
+      )
     }
   }
 })
@@ -107,20 +113,15 @@ test_that("parameter validation works", {
 
 # bayesplot::ppc_dens_overlay(y = as.vector(Y), yrep = model_coa_standard$generated_quantities)
 
-
-
 # rstan::traceplot(fit$model, pars = c("alpha0", "alpha1",
 #                                      "sigma", "lp__"))
-
 
 test_that("test COA_standard model results to make sure its consisitent", {
   mean_p0 <- model_coa_standard$summary[1]
   expected_mean_p0 <- 0.2818
   expect_equal(mean_p0, expected_mean_p0, tolerance = 0.05)
-
 })
 test_that("check to see if model_coa_standard classes", {
-
   expect_type(model_coa_standard, "list")
   expect_s4_class(model_coa_standard$model, "stanfit")
   expect_s3_class(model_coa_standard$coas, "data.frame")
@@ -130,33 +131,35 @@ test_that("check to see if model_coa_standard classes", {
   expect_true(is.matrix(model_coa_standard$generated_quantities$yrep))
   expect_type(model_coa_standard$generated_quantities, "list")
   expect_true(is.numeric(model_coa_standard$time))
-
 })
 
 
-
 test_that("check to see if coa returns proper info", {
-
   expect_true("coas" %in% names(model_coa_standard))
   expect_equal(nrow(model_coa_standard$coas), model_param_ex$tsteps)
-  expect_equal(colnames(model_coa_standard$coas), c(
-    "time", "x", "y", "x_lower",
-    "x_upper", "y_lower", "y_upper"
-  ))
+  expect_equal(
+    colnames(model_coa_standard$coas),
+    c(
+      "time",
+      "x",
+      "y",
+      "x_lower",
+      "x_upper",
+      "y_lower",
+      "y_upper"
+    )
+  )
 
   for (col in colnames(model_coa_standard$coas)) {
     expect_type(model_coa_standard$coas[[col]], "double")
     expect_true(all(is.finite(model_coa_standard$coas[[col]])))
   }
-}
-)
+})
 
 test_that("check to see model converged and has a good rhat", {
-
   rhat <- model_coa_standard$summary[, "Rhat"]
   expect_true(all(rhat > 0.95 & rhat < 1.05))
-}
-)
+})
 
 
 # ----- check if gq retruns the correct length ------
@@ -164,6 +167,4 @@ test_that("check to see model converged and has a good rhat", {
 test_that("check to see if gq is the correct length", {
   expected <- 11
   expect_true(nrow(model_coa_standard$generated_quantities$yrep) %in% expected)
-}
-)
-
+})

--- a/tests/testthat/test-COA_Tag_Integrated.R
+++ b/tests/testthat/test-COA_Tag_Integrated.R
@@ -17,7 +17,7 @@ coa_args <- list(
   testY = array(testloc$north, dim = c(nsentinal)),
   chains = 2,
   warmup = 1000,
-  iter   = 2000,
+  iter = 2000,
   control = list(adapt_delta = 0.95)
 )
 # ----- call coa_tag
@@ -63,12 +63,12 @@ params_table <- list(
   ),
   list(
     param = "recX",
-    bad   = list("bc", NA),
+    bad = list("bc", NA),
     regex = "`recX` must be a numeric vector that has a length of 1."
   ),
   list(
     param = "recY",
-    bad   = list("bc", NA),
+    bad = list("bc", NA),
     regex = "`recY` must be a numeric vector that has a length of 1."
   ),
   list(
@@ -83,12 +83,12 @@ params_table <- list(
   ),
   list(
     param = "testX",
-    bad   = list("bc", NA),
+    bad = list("bc", NA),
     regex = "`testX` must be a numeric array with length equal to 1 \\(the number of test tags\\)\\."
   ),
   list(
     param = "testY",
-    bad   = list("bc", NA),
+    bad = list("bc", NA),
     regex = "`testY` must be a numeric array with length equal to 1 \\(the number of test tags\\)\\."
   )
 )
@@ -97,26 +97,30 @@ params_table
 # ----- Check Params -----
 
 test_that("parameter validation works", {
-
   for (pt in params_table) {
     for (bad_val in pt$bad) {
-      tryCatch({
-        expect_error(
-          call_coa_tagint(setNames(list(bad_val), pt$param)),
-          regexp = pt$regex,
-          label = sprintf("param=%s, bad_val=%s", pt$param, deparse(bad_val))
-        )
-      },
-      error = function(e) {
-        cat("\n Error for param:", pt$param,
-            " bad_val:", deparse(bad_val), "\n")
-        stop(e)
-      })
+      tryCatch(
+        {
+          expect_error(
+            call_coa_tagint(setNames(list(bad_val), pt$param)),
+            regexp = pt$regex,
+            label = sprintf("param=%s, bad_val=%s", pt$param, deparse(bad_val))
+          )
+        },
+        error = function(e) {
+          cat(
+            "\n Error for param:",
+            pt$param,
+            " bad_val:",
+            deparse(bad_val),
+            "\n"
+          )
+          stop(e)
+        }
+      )
     }
   }
 })
-
-
 
 
 # ---- run model and check of it works ----
@@ -133,7 +137,6 @@ test_that("test COA_TagInt model results to make sure its consisitent", {
 
 
 test_that("check to see if model_coa_tag_int classes", {
-
   expect_type(model_coa_tag_int, "list")
   expect_s4_class(model_coa_tag_int$model, "stanfit")
   expect_s3_class(model_coa_tag_int$coas, "data.frame")
@@ -144,39 +147,42 @@ test_that("check to see if model_coa_tag_int classes", {
   expect_true(is.matrix(model_coa_tag_int$generated_quantities$yrep))
   expect_true(is.matrix(model_coa_tag_int$generated_quantities$testrep))
   expect_true(is.numeric(model_coa_tag_int$time))
-
 })
 
 
-
 test_that("check to see if coa returns proper info", {
-
   expect_true("coas" %in% names(model_coa_tag_int))
   expect_equal(nrow(model_coa_tag_int$coas), model_param_ex$tsteps)
-  expect_equal(colnames(model_coa_tag_int$coas), c(
-    "time", "x", "y", "x_lower",
-    "x_upper", "y_lower", "y_upper"
-  ))
+  expect_equal(
+    colnames(model_coa_tag_int$coas),
+    c(
+      "time",
+      "x",
+      "y",
+      "x_lower",
+      "x_upper",
+      "y_lower",
+      "y_upper"
+    )
+  )
 
   for (col in colnames(model_coa_tag_int$coas)) {
     expect_type(model_coa_tag_int$coas[[col]], "double")
     expect_true(all(is.finite(model_coa_tag_int$coas[[col]])))
   }
-}
-)
+})
 
 test_that("check to see model converged and has a good rhat", {
-
   rhat <- model_coa_tag_int$summary[, "Rhat"]
   expect_true(all(rhat > 0.95 & rhat < 1.05))
-}
-)
+})
 
 # ----- check if gq retruns the correct length ------
 
 test_that("check to see if gq is the correct length", {
   expected <- 11
   expect_true(nrow(model_coa_tag_int$generated_quantities$yrep) %in% expected)
-  expect_true(nrow(model_coa_tag_int$generated_quantities$testrep) %in% expected)
-}
-)
+  expect_true(
+    nrow(model_coa_tag_int$generated_quantities$testrep) %in% expected
+  )
+})

--- a/tests/testthat/test-COA_TimeVarying.R
+++ b/tests/testthat/test-COA_TimeVarying.R
@@ -5,18 +5,18 @@
 
 # Base arguments for COA_Standard
 coa_args <- list(
-  nind   = model_param_ex$nind,
-  nrec   = model_param_ex$nrec,
-  ntime  = model_param_ex$tsteps,
+  nind = model_param_ex$nind,
+  nrec = model_param_ex$nrec,
+  ntime = model_param_ex$tsteps,
   ntrans = model_param_ex$ntrans,
-  y      = Y,
-  recX   = rlocs$east,
-  recY   = rlocs$north,
-  xlim   = example_extent$xlim,
-  ylim   = example_extent$ylim,
+  y = Y,
+  recX = rlocs$east,
+  recY = rlocs$north,
+  xlim = example_extent$xlim,
+  ylim = example_extent$ylim,
   chains = 2,
   warmup = 1000,
-  iter   = 2000,
+  iter = 2000,
   control = list(adapt_delta = 0.95)
 )
 
@@ -29,77 +29,78 @@ call_coa_timevarying <- function(overrides) {
 params_table <- list(
   list(
     param = "nind",
-    bad   = list("a", NA, c(1, 2)),
+    bad = list("a", NA, c(1, 2)),
     regex = "`nind` must be a numeric vector that has a length of 1."
   ),
   list(
     param = "nrec",
-    bad   = list("a", NA, c(1, 2)),
+    bad = list("a", NA, c(1, 2)),
     regex = "`nrec` must be a numeric vector that has a length of 1."
   ),
   list(
     param = "ntime",
-    bad   = list("a", NA, c(1, 2)),
+    bad = list("a", NA, c(1, 2)),
     regex = "`ntime` must be a numeric vector that has a length of 1."
   ),
   list(
     param = "ntrans",
-    bad   = list(c(model_param_ex$ntrans, model_param_ex$ntrans), "1"),
+    bad = list(c(model_param_ex$ntrans, model_param_ex$ntrans), "1"),
     regex = "`ntrans` must be a numeric vector that has a length of 1."
   ),
   list(
     param = "y",
-    bad   = list(c(1, 2, 3), "a"),
+    bad = list(c(1, 2, 3), "a"),
     regex = "`y` must be a 3-dimensional numeric array."
   ),
   list(
     param = "recX",
-    bad   = list("a", NA),
+    bad = list("a", NA),
     regex = "`recX` must be a numeric vector that has a length of 1."
   ),
   list(
     param = "recY",
-    bad   = list("a", NA),
+    bad = list("a", NA),
     regex = "`recY` must be a numeric vector that has a length of 1."
   ),
   list(
     param = "xlim",
-    bad   = list("a", c(1, 2, 3)),
+    bad = list("a", c(1, 2, 3)),
     regex = "`xlim` must be a numeric vector that has a length of 2."
   ),
   list(
     param = "ylim",
-    bad   = list("a", c(1, 2, 3)),
+    bad = list("a", c(1, 2, 3)),
     regex = "`ylim` must be a numeric vector that has a length of 2."
   )
 )
 
 # ----- Check Params -----
 
-
 test_that("parameter validation works", {
-
   for (pt in params_table) {
     for (bad_val in pt$bad) {
-      tryCatch({
-        expect_error(
-          call_coa_timevarying(setNames(list(bad_val), pt$param)),
-          regexp = pt$regex,
-          label = sprintf("param=%s, bad_val=%s", pt$param, deparse(bad_val))
-        )
-      },
-      error = function(e) {
-        cat("\n Error for param:", pt$param,
-            " bad_val:", deparse(bad_val), "\n")
-        stop(e)
-      })
+      tryCatch(
+        {
+          expect_error(
+            call_coa_timevarying(setNames(list(bad_val), pt$param)),
+            regexp = pt$regex,
+            label = sprintf("param=%s, bad_val=%s", pt$param, deparse(bad_val))
+          )
+        },
+        error = function(e) {
+          cat(
+            "\n Error for param:",
+            pt$param,
+            " bad_val:",
+            deparse(bad_val),
+            "\n"
+          )
+          stop(e)
+        }
+      )
     }
   }
 })
-
-
-
-
 
 
 # ---- run model and check of it works ----
@@ -119,7 +120,6 @@ test_that("test COA_TimeVarying model results to make sure its consisitent", {
 
 
 test_that("check to see if model_coa_time_vary classes", {
-
   expect_type(model_coa_time_vary, "list")
   expect_s4_class(model_coa_time_vary$model, "stanfit")
   expect_s3_class(model_coa_time_vary$coas, "data.frame")
@@ -129,38 +129,39 @@ test_that("check to see if model_coa_time_vary classes", {
   expect_true(is.matrix(model_coa_time_vary$generated_quantities$yrep))
   expect_type(model_coa_time_vary$generated_quantities, "list")
   expect_true(is.numeric(model_coa_time_vary$time))
-
 })
 
 
-
 test_that("check to see if coa returns proper info", {
-
   expect_true("coas" %in% names(model_coa_time_vary))
   expect_equal(nrow(model_coa_time_vary$coas), model_param_ex$tsteps)
-  expect_equal(colnames(model_coa_time_vary$coas), c(
-    "time", "x", "y", "x_lower",
-    "x_upper", "y_lower", "y_upper"
-  ))
+  expect_equal(
+    colnames(model_coa_time_vary$coas),
+    c(
+      "time",
+      "x",
+      "y",
+      "x_lower",
+      "x_upper",
+      "y_lower",
+      "y_upper"
+    )
+  )
 
   for (col in colnames(model_coa_time_vary$coas)) {
     expect_type(model_coa_time_vary$coas[[col]], "double")
     expect_true(all(is.finite(model_coa_time_vary$coas[[col]])))
   }
-}
-)
+})
 
 test_that("check to see model converged and has a good rhat", {
-
   rhat <- model_coa_time_vary$summary[, "Rhat"]
   expect_true(all(rhat > 0.95 & rhat < 1.05))
-}
-)
+})
 
 # ----- check if gq retruns the correct length ------
 
 test_that("check to see if gq is the correct length", {
   expected <- 11
   expect_true(nrow(model_coa_time_vary$generated_quantities$yrep) %in% expected)
-}
-)
+})

--- a/tests/testthat/test-generated_quantities.R
+++ b/tests/testthat/test-generated_quantities.R
@@ -15,7 +15,7 @@ ndraws_test <- 5
 
 
 # ----- create function to loop over for errors -----
-call_generated_quantities  <- function(overrides) {
+call_generated_quantities <- function(overrides) {
   do.call(generated_quantities, modifyList(gq_args, overrides))
 }
 # ----- gq_arguments to check ------
@@ -42,21 +42,27 @@ params_table <- list(
 
 # ---- see if it errors properly -----
 test_that("parameter validation works", {
-
   for (pt in params_table) {
     for (bad_val in pt$bad) {
-      tryCatch({
-        expect_error(
-          call_generated_quantities(setNames(list(bad_val), pt$param)),
-          regexp = pt$regex,
-          label = sprintf("param=%s, bad_val=%s", pt$param, deparse1(bad_val))
-        )
-      },
-      error = function(e) {
-        cat("\n Error for param:", pt$param,
-            " bad_val:", deparse1(bad_val), "\n")
-        stop(e)
-      })
+      tryCatch(
+        {
+          expect_error(
+            call_generated_quantities(setNames(list(bad_val), pt$param)),
+            regexp = pt$regex,
+            label = sprintf("param=%s, bad_val=%s", pt$param, deparse1(bad_val))
+          )
+        },
+        error = function(e) {
+          cat(
+            "\n Error for param:",
+            pt$param,
+            " bad_val:",
+            deparse1(bad_val),
+            "\n"
+          )
+          stop(e)
+        }
+      )
     }
   }
 })
@@ -68,9 +74,11 @@ yreps <- list()
 # ----- loop over generated quantities -----
 for (i in seq_along(all_models)) {
   # Call your function
-  yreps[[i]] <- generated_quantities(model = all_models[[i]]$model,
-                                     standata = all_data[[i]],
-                                     ndraws = ndraws_test)
+  yreps[[i]] <- generated_quantities(
+    model = all_models[[i]]$model,
+    standata = all_data[[i]],
+    ndraws = ndraws_test
+  )
 }
 
 # length of  each object returned bs = basic_structure
@@ -81,23 +89,19 @@ length_yrep <- ndraws_test
 
 # -----  checks the structure of the structure of generated_quantites -------
 test_that("generated_quantities returns correct structure", {
-
-  for(s in seq_along(yreps)) {
-
+  for (s in seq_along(yreps)) {
     bs <- yreps[[s]]
 
     expect_type(bs, "list")
     expect_length(bs, bs_returned[s])
 
     for (n in seq_along(bs)) {
-
       post_draws <- bs[[n]]
 
       expect_type(post_draws, "list")
       expect_length(post_draws, length_yrep)
 
       for (h in seq_along(post_draws)) {
-
         one_draw <- post_draws[[h]]
 
         expect_true(is.array(one_draw))
@@ -111,15 +115,12 @@ test_that("generated_quantities returns correct structure", {
       }
     }
   }
-}
-)
+})
 
 
 # do not test actual values as these will change
 test_that("generated_quantities returns correct integer ", {
-
-  for(s in seq_along(yreps)) {
-
+  for (s in seq_along(yreps)) {
     bs <- yreps[[s]]
 
     for (n in seq_along(bs)) {
@@ -128,6 +129,4 @@ test_that("generated_quantities returns correct integer ", {
       expect_type(one_draw, "integer")
     }
   }
-}
-)
-
+})

--- a/tests/testthat/test-transform_gq.R
+++ b/tests/testthat/test-transform_gq.R
@@ -19,9 +19,11 @@ yreps <- list()
 # ----- loop over generated quantities -----
 for (i in seq_along(all_models)) {
   # Call your function
-  yreps[[i]] <- generated_quantities(model = all_models[[i]]$model,
-                                     standata = all_data[[i]],
-                                     ndraws = ndraws_test)
+  yreps[[i]] <- generated_quantities(
+    model = all_models[[i]]$model,
+    standata = all_data[[i]],
+    ndraws = ndraws_test
+  )
 }
 
 
@@ -30,7 +32,6 @@ bs_returned <- c(1, 1, 2)
 bs_names <- c(rep("yrep", 3), "testrep")
 
 test_that("check transformation of gq to matrix", {
-
   for (i in seq_along(yreps)) {
     tran_gq <- transform_gq(yreps[[i]])
 
@@ -40,7 +41,6 @@ test_that("check transformation of gq to matrix", {
     expect_true(bs_names[i] %in% names(tran_gq))
 
     for (n in seq_along(tran_gq)) {
-
       post_draws <- tran_gq[[n]]
       expect_type(post_draws, "integer")
       expect_true(is.matrix(post_draws))
@@ -49,11 +49,9 @@ test_that("check transformation of gq to matrix", {
 })
 
 test_that("check row and column names of gq in matrix", {
-
   for (i in seq_along(yreps)) {
     tran_gq <- transform_gq(yreps[[i]])
     for (n in seq_along(tran_gq)) {
-
       post_draws <- tran_gq[[n]]
       # check row names
       expect_true(all(grepl("^(yrep|testrep)_[0-9]+$", rownames(post_draws))))
@@ -62,17 +60,13 @@ test_that("check row and column names of gq in matrix", {
       expect_true(all(grepl(
         "^tag_[0-9]+_rec_[0-9]+_time_[0-9]+$",
         colnames(post_draws)
-      )
-      )
-      )
+      )))
       # also check correct counts
       expect_length(rownames(post_draws), nrow(post_draws))
       expect_length(colnames(post_draws), ncol(post_draws))
     }
   }
 })
-
-
 
 #   for (i in 1:n_draws) {
 #     y_rep_mat[i, ] <- as.vector(draws$yrep[i, , , ])
@@ -83,4 +77,3 @@ test_that("check row and column names of gq in matrix", {
 #     expect_true(all(y_rep_mat[i, ] >= 0 &  y_rep_mat[i, ] <= 25))
 #   }
 # }
-


### PR DESCRIPTION
I accidentally pushed the `air.toml` file that `usethis::use_air()` creates to main. I ran air on the whole repo and these changes are formatting changes that air did. We should/I know you have implemented a GH styler and I know there is one for air as well.

No actual changes to the code just reformatting